### PR TITLE
Added a helper to authenticate against a specific tenant/Azure app.

### DIFF
--- a/auth-helper-azure.ts
+++ b/auth-helper-azure.ts
@@ -1,0 +1,26 @@
+/// <reference path="references.d.ts" />
+
+import * as tnsOauth from './tns-oauth';
+import { AuthHelper } from './auth-helper';
+import * as TnsOAuth from './tns-oauth-interfaces';
+
+export class AuthHelperAzure extends AuthHelper implements TnsOAuth.ITnsAuthHelper {
+
+  constructor(clientId: string, scope: Array<string>, tenant: string) {
+    super();
+    var scopeStr = scope.join('%20');
+    this.credentials = {
+      authority: 'https://login.microsoftonline.com/' + tenant,
+      authorizeEndpoint: '/oauth2/authorize',
+      tokenEndpoint: '/oauth2/token',
+      clientId: clientId,
+      redirectUri: 'urn:ietf:wg:oauth:2.0:oob',
+      scope: scopeStr
+    };
+  }
+
+  public logout(successPage?: string): Promise<void> {
+    let cookieDomains = ["login.microsoftonline.com", ".live.com"];
+    return this._logout(successPage, cookieDomains);
+  }
+}

--- a/demo/app/app.ts
+++ b/demo/app/app.ts
@@ -11,14 +11,14 @@ import * as tnsOAuthModule from 'nativescript-oauth';
 
 
 var azureInitOptions: tnsOAuthModule.ITnsOAuthOptionsAzure = {
-    clientId: 'a44ea48e-22ec-473e-a7f7-dc4b001aaa54', //client id for application (GUID)
+    clientId: '12345', //client id for application (GUID)
     scope: ['openid'],
     tenant: 'SOME_TEST_TENANT'
 };
 
 var o365InitOptions: tnsOAuthModule.ITnsOAuthOptionsOffice365 = {
-    clientId: 'a44ea48e-22ec-473e-a7f7-dc4b001aaa54', //client id for application (GUID)
-    scope: ['openid']
+    clientId: '31e1c318-a133-432f-a53b-5122ceab4c12', //client id for application (GUID)
+    scope: ['Files.ReadWrite', 'User.ReadWrite', 'offline_access']
 };
 
 var facebookInitOptions: tnsOAuthModule.ITnsOAuthOptionsFacebook = {
@@ -27,9 +27,9 @@ var facebookInitOptions: tnsOAuthModule.ITnsOAuthOptionsFacebook = {
     scope: ['email']
 };
 
-tnsOAuthModule.initAzure(azureInitOptions);
+//tnsOAuthModule.initAzure(azureInitOptions);
 //tnsOAuthModule.initOffice365(o365InitOptions);
-//tnsOAuthModule.initFacebook(facebookInitOptions);
+tnsOAuthModule.initFacebook(facebookInitOptions);
 
 trace.setCategories(trace.categories.All);
 trace.enable();

--- a/demo/app/app.ts
+++ b/demo/app/app.ts
@@ -10,9 +10,15 @@ import trace = require("trace");
 import * as tnsOAuthModule from 'nativescript-oauth';
 
 
+var azureInitOptions: tnsOAuthModule.ITnsOAuthOptionsAzure = {
+    clientId: 'a44ea48e-22ec-473e-a7f7-dc4b001aaa54', //client id for application (GUID)
+    scope: ['openid'],
+    tenant: 'SOME_TEST_TENANT'
+};
+
 var o365InitOptions: tnsOAuthModule.ITnsOAuthOptionsOffice365 = {
-    clientId: '31e1c318-a133-432f-a53b-5122ceab4c12', //client id for application (GUID)
-    scope: ['Files.ReadWrite', 'User.ReadWrite', 'offline_access']
+    clientId: 'a44ea48e-22ec-473e-a7f7-dc4b001aaa54', //client id for application (GUID)
+    scope: ['openid']
 };
 
 var facebookInitOptions: tnsOAuthModule.ITnsOAuthOptionsFacebook = {
@@ -21,8 +27,9 @@ var facebookInitOptions: tnsOAuthModule.ITnsOAuthOptionsFacebook = {
     scope: ['email']
 };
 
+tnsOAuthModule.initAzure(azureInitOptions);
 //tnsOAuthModule.initOffice365(o365InitOptions);
-tnsOAuthModule.initFacebook(facebookInitOptions);
+//tnsOAuthModule.initFacebook(facebookInitOptions);
 
 trace.setCategories(trace.categories.All);
 trace.enable();

--- a/demo/app/main-view-model.ts
+++ b/demo/app/main-view-model.ts
@@ -13,6 +13,7 @@ export class HelloWorldModel extends Observable {
         tnsOAuthModule.ensureValidToken()
             .then((token: string) => {
                 console.log('token: ' + token);
+                console.log('id token: ' + tnsOAuthModule.idToken());
             })
             .catch((er) => {
                 console.error('error logging in');

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,12 +3,14 @@ import * as TnsOAuth from './tns-oauth-interfaces';
 export * from './tns-oauth-interfaces';
 
 export declare var instance: TnsOAuth.ITnsAuthHelper;
+export declare function initAzure(options: TnsOAuth.ITnsOAuthOptionsAzure): Promise<any>;
 export declare function initOffice365(options: TnsOAuth.ITnsOAuthOptionsOffice365): Promise<any>;
 export declare function initFacebook(options: TnsOAuth.ITnsOAuthOptionsFacebook): Promise<any>;
 export declare function initGoogle(options: TnsOAuth.ITnsOAuthOptionsGoogle): Promise<any>;
 export declare function initUaa(options: TnsOAuth.ITnsOAuthOptionsUaa): Promise<any>;
 export declare function initLinkedIn(options: TnsOAuth.ITnsOAuthOptionsLinkedIn): Promise<any>;
 
+export declare function idToken(): string;
 export declare function accessToken(): string;
 export declare function login(successPage?: string): Promise<string>;
 export declare function logout(successPage?: string): Promise<void>;

--- a/index.ts
+++ b/index.ts
@@ -9,8 +9,10 @@ import { AuthHelperFacebook } from './auth-helper-facebook';
 import { AuthHelperGoogle } from './auth-helper-google';
 import { AuthHelperUaa } from './auth-helper-uaa';
 import { AuthHelperLinkedIn } from './auth-helper-linkedin';
+import { AuthHelperAzure } from "./auth-helper-azure";
 
 import * as TnsOAuth from './tns-oauth-interfaces';
+
 
 export var instance: TnsOAuth.ITnsAuthHelper = null;
 
@@ -26,6 +28,23 @@ export function initOffice365(options: TnsOAuth.ITnsOAuthOptionsOffice365): Prom
             resolve(instance);
         } catch (ex) {
             console.log("Error in AuthHelperOffice365.init: " + ex);
+            reject(ex);
+        }
+    });
+}
+
+export function initAzure(options: TnsOAuth.ITnsOAuthOptionsAzure): Promise<any> {
+    return new Promise(function (resolve, reject) {
+        try {
+            if (instance !== null) {
+                reject("You already ran init");
+                return;
+            }
+
+            instance = new AuthHelperAzure(options.clientId, options.scope, options.tenant);
+            resolve(instance);
+        } catch (ex) {
+            console.log("Error in AuthHelperAzure.init: " + ex);
             reject(ex);
         }
     });
@@ -104,6 +123,10 @@ export function initLinkedIn(options: TnsOAuth.ITnsOAuthOptionsLinkedIn): Promis
 
 export function accessToken(): string {
     return instance.tokenResult.accessToken;
+}
+
+export function idToken(): string {
+    return instance.tokenResult.idToken;
 }
 
 export function login(successPage?: string): Promise<string> {

--- a/tns-oauth-interfaces.d.ts
+++ b/tns-oauth-interfaces.d.ts
@@ -31,6 +31,7 @@ export interface ITnsOAuthTokenResult {
     refreshToken: string;
     accessTokenExpiration: Date;
     refreshTokenExpiration: Date;
+    idToken: string;
 }
 
 export interface ITnsOAuthOptions {
@@ -39,6 +40,10 @@ export interface ITnsOAuthOptions {
 }
 
 export interface ITnsOAuthOptionsOffice365 extends ITnsOAuthOptions {
+}
+
+export interface ITnsOAuthOptionsAzure extends ITnsOAuthOptions {
+    tenant: string;
 }
 
 export interface ITnsOAuthOptionsFacebook extends ITnsOAuthOptions {

--- a/tns-oauth.ts
+++ b/tns-oauth.ts
@@ -337,9 +337,14 @@ class TnsOAuth {
                         // being thrown
                         results = querystring.parse(response.content.toString());
                     }
+
                     let access_token = results["access_token"];
                     let refresh_token = results["refresh_token"];
                     let expires_in = results["expires_in"];
+
+                    // Some Azure apps need the id_token instead of the access_token.
+                    let id_token = results["id_token"] || '';
+
                     delete results["refresh_token"];
 
                     let expSecs = Math.floor(parseFloat(expires_in));
@@ -350,7 +355,8 @@ class TnsOAuth {
                         accessToken: access_token,
                         refreshToken: refresh_token,
                         accessTokenExpiration: expDate,
-                        refreshTokenExpiration: expDate
+                        refreshTokenExpiration: expDate,
+                        idToken: id_token
                     };
 
                     resolve(tokenResult);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     },
     "files": [
         "auth-helper.ts",
+        "auth-helper-azure.ts",
         "auth-helper-facebook.ts",
         "auth-helper-google.ts",
         "auth-helper-office365.ts",


### PR DESCRIPTION
Hi,

I've got some older Azure app services which need take a JWT bearer token which is in the `id_token` key in the JSON.

I've added an Azure app helper which accepts an extra tenant parameter in the options JSON.

I've also added a function to retrieve the `id_token` from the bearer.

I've tried to follow all existing patterns, please let me know if anything else needs changing.

Kind regards,

Adam
