### PR TITLE
Add web pack support to the demo app

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -12,11 +12,23 @@
       "version": "3.0.0"
     }
   },
+  "scripts": {
+    "build.plugin": "cd .. && npm run build",
+    "demo.ios": "npm i && npm run build.plugin && tns run ios",
+    "demo.android": "npm i && npm run build.plugin && tns run android",
+    "ns-bundle": "ns-bundle",
+    "start-android-bundle": "npm run ns-bundle --android --run-app",
+    "start-ios-bundle": "npm run ns-bundle --ios --run-app",
+    "build-android-bundle": "npm run ns-bundle --android --build-app",
+    "build-ios-bundle": "npm run ns-bundle --ios --build-app",
+    "publish-ios-bundle": "npm run ns-bundle --ios --publish-app",
+    "generate-android-snapshot": "generate-android-snapshot --targetArchs arm,arm64,ia32 --install"
+  },
   "dependencies": {
     "nativescript-oauth": "../",
     "nativescript-theme-core": "~1.0.2",
-    "tns-core-modules": "3.0.0",
-    "tns-platform-declarations": "3.0.1"
+    "tns-core-modules": "~3.0.0",
+    "tns-platform-declarations": "~3.0.1"
   },
   "devDependencies": {
     "babel-traverse": "6.24.1",
@@ -25,6 +37,16 @@
     "lazy": "1.0.11",
     "nativescript-dev-android-snapshot": "^0.*.*",
     "nativescript-dev-typescript": "~0.4.0",
-    "typescript": "~2.2.1"
+    "typescript": "~2.2.1",
+    "nativescript-dev-webpack": "0.7.3",
+    "webpack": "~3.2.0",
+    "webpack-bundle-analyzer": "^2.8.2",
+    "webpack-sources": "~1.0.1",
+    "copy-webpack-plugin": "~4.0.1",
+    "raw-loader": "~0.5.1",
+    "nativescript-css-loader": "~0.26.0",
+    "resolve-url-loader": "~2.1.0",
+    "extract-text-webpack-plugin": "~3.0.0",
+    "awesome-typescript-loader": "~3.1.3"
   }
 }

--- a/demo/package.json
+++ b/demo/package.json
@@ -17,12 +17,12 @@
     "demo.ios": "npm i && npm run build.plugin && tns run ios",
     "demo.android": "npm i && npm run build.plugin && tns run android",
     "ns-bundle": "ns-bundle",
+    "publish-ios-bundle": "npm run ns-bundle --ios --publish-app",
+    "generate-android-snapshot": "generate-android-snapshot --targetArchs arm,arm64,ia32 --install",
     "start-android-bundle": "npm run ns-bundle --android --run-app",
     "start-ios-bundle": "npm run ns-bundle --ios --run-app",
     "build-android-bundle": "npm run ns-bundle --android --build-app",
-    "build-ios-bundle": "npm run ns-bundle --ios --build-app",
-    "publish-ios-bundle": "npm run ns-bundle --ios --publish-app",
-    "generate-android-snapshot": "generate-android-snapshot --targetArchs arm,arm64,ia32 --install"
+    "build-ios-bundle": "npm run ns-bundle --ios --build-app"
   },
   "dependencies": {
     "nativescript-oauth": "../",

--- a/demo/package.json
+++ b/demo/package.json
@@ -27,8 +27,7 @@
   "dependencies": {
     "nativescript-oauth": "../",
     "nativescript-theme-core": "~1.0.2",
-    "tns-core-modules": "~3.0.0",
-    "tns-platform-declarations": "~3.0.1"
+    "tns-core-modules": "~3.0.0"
   },
   "devDependencies": {
     "babel-traverse": "6.24.1",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "devDependencies": {
     "nativescript-dev-typescript": "^0.4.0",
     "tns-core-modules": "~3.0.0",
-    "typescript": "~2.2.2"
+    "typescript": "~2.2.2",
+    "tns-platform-declarations": "~3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsc",
-    "demo.ios": "npm run preparedemo && cd demo-angular && tns emulate ios",
+    "build": "npm i && tsc",
     "demo.android": "npm run preparedemo && cd demo-angular && tns run android",
     "preparedemo": "npm run build && cd demo-angular && tns plugin remove nativescript-oauth && tns plugin add .. && tns install",
     "setup": "cd demo-angular && npm install && cd .. && npm run build && cd demo-angular && tns plugin add .. && cd .."
@@ -68,7 +67,7 @@
   },
   "devDependencies": {
     "nativescript-dev-typescript": "^0.4.0",
-    "tns-core-modules": "3.0.0",
-    "typescript": "^2.2.1"
+    "tns-core-modules": "~3.0.0",
+    "typescript": "~2.2.2"
   }
 }

--- a/references.d.ts
+++ b/references.d.ts
@@ -1,5 +1,5 @@
-/// <reference path="demo/node_modules/tns-platform-declarations/ios.d.ts" />
-/// <reference path="demo/node_modules/tns-platform-declarations/android.d.ts" />
+/// <reference path="./node_modules/tns-platform-declarations/ios.d.ts" />
+/// <reference path="./node_modules/tns-platform-declarations/android.d.ts" />
 
 // <reference path="demo/node_modules/tns-platform-declarations/tns-core-modules/org.nativescript.widgets.d.ts" /> 
 /// <reference path="./index.d.ts" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
         "noLib": false,
         "preserveConstEnums": true,
         "declaration": false,
+        "noEmitHelpers": true,
         "suppressImplicitAnyIndexErrors": true,
         "lib": [
             "es6",


### PR DESCRIPTION
@alexziskind1 I think this is a good example how to add webpack support. Please try to add webpack to the demo-angular app and let me know if you have any problems. Bare in mind that after installing of nativescript-dev-webpack it adds some dependencies to the package.json file.