### PR TITLE
feat(office365): add tenant specific parameter

### DIFF
--- a/auth-helper-office365.ts
+++ b/auth-helper-office365.ts
@@ -6,11 +6,11 @@ import * as TnsOAuth from './tns-oauth-interfaces';
 
 export class AuthHelperOffice365 extends AuthHelper implements TnsOAuth.ITnsAuthHelper {
 
-  constructor(clientId: string, scope: Array<string>) {
+  constructor(tenantId:string ='common', clientId: string, scope: Array<string>) {
     super();
     var scopeStr = scope.join('%20');
     this.credentials = {
-      authority: 'https://login.microsoftonline.com/common',
+      authority: `https://login.microsoftonline.com/${tenantId}`,
       authorizeEndpoint: '/oauth2/v2.0/authorize',
       tokenEndpoint: '/oauth2/v2.0/token',
       clientId: clientId,

--- a/index.ts
+++ b/index.ts
@@ -23,7 +23,7 @@ export function initOffice365(options: TnsOAuth.ITnsOAuthOptionsOffice365): Prom
                 return;
             }
 
-            instance = new AuthHelperOffice365(options.clientId, options.scope);
+            instance = new AuthHelperOffice365(options.tenantId, options.clientId, options.scope);
             resolve(instance);
         } catch (ex) {
             console.log("Error in AuthHelperOffice365.init: " + ex);

--- a/tns-oauth-interfaces.d.ts
+++ b/tns-oauth-interfaces.d.ts
@@ -41,6 +41,7 @@ export interface ITnsOAuthOptions {
 }
 
 export interface ITnsOAuthOptionsOffice365 extends ITnsOAuthOptions {
+    tenantId: string;
 }
 
 export interface ITnsOAuthOptionsFacebook extends ITnsOAuthOptions {


### PR DESCRIPTION
This pull request add a tenantId value as an option for office365 oauth that can be used to control who can sign into the application.
The allowed values  are tenant identifiers, for example, 8eaef023-2b34-4da1-9baa-8bc8c9d6a490 or contoso.onmicrosoft.com or common for tenant-independent tokens which is the default value.

The new option can be used as below
```
var o365InitOptions: tnsOAuthModule.ITnsOAuthOptionsOffice365 = {
    tenantId: 'contoso.onmicrosoft.com',//specific tenant id
    clientId: '61f851ae-3b42-4ef9-8c11-xxxxxxxxxxxxx', //client id for application (GUID)
    scope: ['Files.ReadWrite', 'User.ReadWrite', 'offline_access']
};
tnsOAuthModule.initOffice365(o365InitOptions);
```

This will allow to use the authorizeEndpoint as `https://login.microsoftonline.com/contoso.onmicrosoft.com/oauth2/v2.0/authorize` and the tokenEndpoint as `https://login.microsoftonline.com/contoso.onmicrosoft.com/oauth2/v2.0/token` for the OAuth 2.0 authorization flow.

If no tenantId is specified the `common` endpoint is used by default.

Thanks for the plugin.




