### PR TITLE
Reject login promise on user cancel

### DIFF
--- a/tns-oauth-page-provider.ts
+++ b/tns-oauth-page-provider.ts
@@ -3,22 +3,24 @@
 import { Page } from 'ui/page';
 import { GridLayout } from 'ui/layouts/grid-layout';
 import { StackLayout } from 'ui/layouts/stack-layout';
-import { WebView } from 'ui/web-view';
+import { TnsOauthWebView } from './tns-oauth-webview';
 //import { TnsOAuthWebViewDelegateImpl } from './tns-oauth-webview';
 import { TnsOAuthWebViewHelper } from './tns-oauth-webview-helper';
 
 
 export class TnsOAuthPageProvider {
     private _checkCodeIntercept: (WebView, error?, url?) => boolean;
+    private _cancelEventHandler: (error?) => void;
     private _authUrl: string;
 
-    constructor(checkCodeIntercept, authUrl) {
+    constructor(checkCodeIntercept, authUrl, cancelEventHandler) {
         this._checkCodeIntercept = checkCodeIntercept;
+        this._cancelEventHandler = cancelEventHandler;
         this._authUrl = authUrl;
     }
 
     public loginPageFunc() {
-        let wv = new WebView();
+        let wv = new TnsOauthWebView(this._cancelEventHandler);
 
         TnsOAuthWebViewHelper.initWithWebViewAndIntercept(wv, this._checkCodeIntercept);
 

--- a/tns-oauth-webview.ts
+++ b/tns-oauth-webview.ts
@@ -1,0 +1,16 @@
+/// <reference path="references.d.ts" />
+
+import { WebView } from 'ui/web-view';
+
+export class TnsOauthWebView extends WebView {
+  constructor(
+    private _cancelEventHandler: (error?) => void
+  ) {
+    super();
+  }
+
+  public onUnloaded() {
+    super.onUnloaded();
+    this._cancelEventHandler();
+  }
+}

--- a/tns-oauth-webview.ts
+++ b/tns-oauth-webview.ts
@@ -3,14 +3,14 @@
 import { WebView } from 'ui/web-view';
 
 export class TnsOauthWebView extends WebView {
-  constructor(
-    private _cancelEventHandler: (error?) => void
-  ) {
-    super();
-  }
+    constructor(
+        private _cancelEventHandler: (error?) => void
+    ) {
+        super();
+    }
 
-  public onUnloaded() {
-    super.onUnloaded();
-    this._cancelEventHandler("User cancelled.");
-  }
+    public onUnloaded() {
+        super.onUnloaded();
+        this._cancelEventHandler("User cancelled.");
+    }
 }

--- a/tns-oauth-webview.ts
+++ b/tns-oauth-webview.ts
@@ -11,6 +11,6 @@ export class TnsOauthWebView extends WebView {
 
   public onUnloaded() {
     super.onUnloaded();
-    this._cancelEventHandler();
+    this._cancelEventHandler("User cancelled.");
   }
 }

--- a/tns-oauth.ts
+++ b/tns-oauth.ts
@@ -177,7 +177,7 @@ export function loginViaAuthorizationCodeFlow(credentials: TnsOAuthModule.ITnsOA
         };
 
         console.log('LOGIN PAGE URL = ' + getAuthUrl(credentials));
-        let authPage = new TnsOAuthPageProvider(checkCodeIntercept, getAuthUrl(credentials));
+        let authPage = new TnsOAuthPageProvider(checkCodeIntercept, getAuthUrl(credentials), reject);
         frameModule.topmost().navigate(() => { return authPage.loginPageFunc() });
     });
 }


### PR DESCRIPTION
Currently, if the user presses the back button to exit the login WebView, the login promise never completes. This can create a few issues:

* It's a memory leak, albeit a small one
* It can stall the flow when creating an observable from the promise (such as for use with ngrx)

This PR rejects the promise when the WebView unloads. This works because the web view interceptor runs before unload, so if the promise is going to resolve or reject from that, it still will normally. But, if the view unloads with the promise never being handled, then the new code will reject the promise.