### PR TITLE
NativeScript 4 and import helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,9 +61,10 @@
     "url": "^0.11.0"
   },
   "devDependencies": {
-    "nativescript-dev-typescript": "^0.5.0",
-    "tns-core-modules": "3.4.1",
-    "typescript": "2.3.4",
-    "tns-platform-declarations": "3.4.1"
+    "nativescript-dev-typescript": "^0.7.1",
+    "tns-core-modules": "4.1.0",
+    "typescript": "2.7.1",
+    "tns-platform-declarations": "4.1.0",
+    "tslib": "1.7.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
         "noLib": false,
         "preserveConstEnums": true,
         "declaration": false,
-        "noEmitHelpers": true,
+        "importHelpers": true,
         "suppressImplicitAnyIndexErrors": true,
         "lib": [
             "es6",


### PR DESCRIPTION
Quality of life improvements:

Switch to NativeScript 4. This library doesn't do anything fancy enough to require any migrations.

Turn on TypeScript's importHelpers to make this work with Webpack in newer NativeScript templates.