### PR TITLE
Changes to make library support multiple login options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 ![npm-downloads-per-week](https://img.shields.io/npm/dw/nativescript-oauth.svg)
 
+This is a modification in the original library that we use to allow multiple login options to the end-user.
+
+The original library only allowed initially with one of Facebook, LinkedIn etc.
+
+Instead of calling init[Provider] at main.ts or app.ts, call it when the end user clicks on the "Login with [Provider]" button and on resolving the promise there, call the login method.
+
+Wrap the logout method with a if (5===5) { tnsOAuthModule.logout()...} so that at run-time, it does not throw an exception.
+
+I've also modified the library so that clicking cancel on the LinkedIn Auth page goes back to the previous webview instead of it attempting to load the linkedIn redirect URL.
+
 Library for interacting with OAuth 2.0 in NativeScript applications that provides simplified client access with a OAuth providers that support the OAuth 2.0 protocol such as Microsoft Live accounts, Microsoft Graph, Office 365, Facebook, Cloud Foundry UAA instances, LinkedIn, and Google (Google is a work in progress due to some of their restrictions).
 
 **_NEW:_** **Now supports NativeScript 4.1.0!**

--- a/index.ts
+++ b/index.ts
@@ -19,10 +19,10 @@ export var instance: TnsOAuth.ITnsAuthHelper = null;
 export function initOffice365(options: TnsOAuth.ITnsOAuthOptionsOffice365): Promise<any> {
     return new Promise(function (resolve, reject) {
         try {
-            if (instance !== null) {
-                reject("You already ran init");
-                return;
-            }
+            // if (instance !== null) {
+            //     reject("You already ran init");
+            //     return;
+            // }
 
             instance = new AuthHelperOffice365(options.clientId, options.scope);
             resolve(instance);
@@ -36,10 +36,10 @@ export function initOffice365(options: TnsOAuth.ITnsOAuthOptionsOffice365): Prom
 export function initFacebook(options: TnsOAuth.ITnsOAuthOptionsFacebook): Promise<any> {
     return new Promise(function (resolve, reject) {
         try {
-            if (instance !== null) {
-                reject("You already ran init");
-                return;
-            }
+            // if (instance !== null) {
+            //     reject("You already ran init");
+            //     return;
+            // }
 
             instance = new AuthHelperFacebook(options.clientId, options.clientSecret, options.scope);
             resolve(instance);
@@ -53,10 +53,10 @@ export function initFacebook(options: TnsOAuth.ITnsOAuthOptionsFacebook): Promis
 export function initGoogle(options: TnsOAuth.ITnsOAuthOptionsGoogle): Promise<any> {
     return new Promise(function (resolve, reject) {
         try {
-            if (instance !== null) {
-                reject("You already ran init");
-                return;
-            }
+            // if (instance !== null) {
+            //     reject("You already ran init");
+            //     return;
+            // }
 
             instance = new AuthHelperGoogle(options.clientId, options.scope);
             resolve(instance);
@@ -71,10 +71,10 @@ export function initGoogle(options: TnsOAuth.ITnsOAuthOptionsGoogle): Promise<an
 export function initUaa(options: TnsOAuth.ITnsOAuthOptionsUaa): Promise<any> {
     return new Promise(function (resolve, reject) {
         try {
-            if (instance !== null) {
-                reject("You already ran init");
-                return;
-            }
+            // if (instance !== null) {
+            //     reject("You already ran init");
+            //     return;
+            // }
 
             instance = new AuthHelperUaa(options.authority, options.redirectUri, options.clientId, options.clientSecret, options.scope, options.cookieDomains, options.basicAuthHeader);
             resolve(instance);
@@ -89,10 +89,10 @@ export function initUaa(options: TnsOAuth.ITnsOAuthOptionsUaa): Promise<any> {
 export function initLinkedIn(options: TnsOAuth.ITnsOAuthOptionsLinkedIn): Promise<any> {
     return new Promise(function (resolve, reject) {
         try {
-            if (instance !== null) {
-                reject("You already ran init");
-                return;
-            }
+            // if (instance !== null) {
+            //     reject("You already ran init");
+            //     return;
+            // }
 
             instance = new AuthHelperLinkedIn(options.clientId, options.clientSecret, options.redirectUri, options.scope);
             resolve(instance);
@@ -106,10 +106,10 @@ export function initLinkedIn(options: TnsOAuth.ITnsOAuthOptionsLinkedIn): Promis
 export function initSalesforce(options: TnsOAuth.ITnsOAuthOptionsSalesforce): Promise<any> {
     return new Promise(function (resolve, reject) {
         try {
-            if (instance !== null) {
-                reject("You already ran init");
-                return;
-            }
+            // if (instance !== null) {
+            //     reject("You already ran init");
+            //     return;
+            // }
 
             instance = new AuthHelperSalesforce(
                 options.authority,
@@ -129,10 +129,10 @@ export function initSalesforce(options: TnsOAuth.ITnsOAuthOptionsSalesforce): Pr
 export function initCustom(options: TnsOAuth.ITnsOAuthOptionsCustom): Promise<any> {
     return new Promise(function (resolve, reject) {
         try {
-            if (instance !== null) {
-                reject("You already ran init");
-                return;
-            }
+            // if (instance !== null) {
+            //     reject("You already ran init");
+            //     return;
+            // }
 
             instance = new AuthHelperCustom(options.credentials, options.cookieDomains);
             resolve(instance);

--- a/tns-oauth-page-provider.ts
+++ b/tns-oauth-page-provider.ts
@@ -7,21 +7,41 @@ import { isAndroid } from 'tns-core-modules/platform';
 import { TnsOauthWebView } from './tns-oauth-webview';
 //import { TnsOAuthWebViewDelegateImpl } from './tns-oauth-webview';
 import { TnsOAuthWebViewHelper } from './tns-oauth-webview-helper';
+import { WebView } from 'ui/web-view';
+import { topmost } from "ui/frame";
 
 
 export class TnsOAuthPageProvider {
     private _checkCodeIntercept: (WebView, error?, url?) => boolean;
     private _cancelEventHandler: (error?) => void;
     private _authUrl: string;
+    private _redirectUrl: string;
 
-    constructor(checkCodeIntercept, authUrl, cancelEventHandler) {
+    constructor(checkCodeIntercept, authUrl, cancelEventHandler, redirectUrl) {
         this._checkCodeIntercept = checkCodeIntercept;
         this._cancelEventHandler = cancelEventHandler;
         this._authUrl = authUrl;
+        this._redirectUrl = redirectUrl;
     }
 
     public loginPageFunc() {
         let wv = new TnsOauthWebView(this._cancelEventHandler);
+
+        wv.on(WebView.loadStartedEvent, (args: any) => {
+            const url = args.url;
+            console.log('Redirect URL');
+            console.log(this._redirectUrl);
+
+            // Handle LinkedIn Cancel button clicked by stopping loading and exiting the web view
+            if (url.toLowerCase().startsWith(this._redirectUrl.toLowerCase())) {
+                console.log('Inside redirect URL');
+                if (args.url.indexOf('error=') > -1) {
+                    console.log('Aborting login as user clicked cancel');
+                    wv.stopLoading();
+                    topmost().goBack();
+                }
+            }
+        });
 
         TnsOAuthWebViewHelper.initWithWebViewAndIntercept(wv, this._checkCodeIntercept);
 

--- a/tns-oauth.ts
+++ b/tns-oauth.ts
@@ -177,7 +177,7 @@ export function loginViaAuthorizationCodeFlow(credentials: TnsOAuthModule.ITnsOA
         };
 
         console.log('LOGIN PAGE URL = ' + getAuthUrl(credentials));
-        let authPage = new TnsOAuthPageProvider(checkCodeIntercept, getAuthUrl(credentials), reject);
+        let authPage = new TnsOAuthPageProvider(checkCodeIntercept, getAuthUrl(credentials), reject, credentials.redirectUri);
         frameModule.topmost().navigate(() => { return authPage.loginPageFunc() });
     });
 }


### PR DESCRIPTION
From what I understand, your plugin can only support initialising with one provider. But a lot of apps offer multiple login providers.

I've tested this extensively with an app I'm working on right now and it seems to work perfectly fine. Your login function needs to be wrapped in a "if (true) {...}" block to keep it from causing a run-time crash.

I realize this can't be merged in as it right now. Just wanted to hear your thoughts on the way I've made these changes. 