### PR TITLE
Fixed linkedin cancel button not going back on the app.

### DIFF
--- a/tns-oauth.ts
+++ b/tns-oauth.ts
@@ -132,7 +132,7 @@ export function loginViaAuthorizationCodeFlow(credentials: TnsOAuthModule.ITnsOA
                 if (parsedRetStr.query) {
                     let qsObj = querystring.parse(parsedRetStr.query);
                     let codeStr = qsObj['code'] ? qsObj['code'] : qsObj['xsrfsign'];
-                    let errSubCode = qsObj['error_subcode'];
+                    let errSubCode = qsObj['error_subcode'] || qsObj.error;
                     if (codeStr) {
                         try {
                             getTokenFromCode(credentials, codeStr)
@@ -162,7 +162,7 @@ export function loginViaAuthorizationCodeFlow(credentials: TnsOAuthModule.ITnsOA
                         return true;
                     } else {
                         if (errSubCode) {
-                            if (errSubCode == 'cancel') {
+                            if (errSubCode == 'cancel' || errSubCode === 'user_cancelled_login') {
                                 frameModule.topmost().goBack();
                             }
                         }


### PR DESCRIPTION
When clicking the cancel button for linkedin, app was redirecting to redirectUri instead of going back to the app page.