### PR TITLE
Add navigation options to login and logout calls

### DIFF
--- a/auth-helper-custom.ts
+++ b/auth-helper-custom.ts
@@ -16,7 +16,7 @@ export class AuthHelperCustom extends AuthHelper implements TnsOAuth.ITnsAuthHel
         this.credentials.scope = credentials.scope.replace(/ /g, '%20');
     }
 
-    public logout(successPage?: string): Promise<void> {
-        return this._logout(successPage, this.cookieDomains);
+    public logout(navOptions?: TnsOAuth.INavigationOptions): Promise<void> {
+        return this._logout(navOptions, this.cookieDomains);
     }
 }

--- a/auth-helper-facebook.ts
+++ b/auth-helper-facebook.ts
@@ -21,8 +21,8 @@ export class AuthHelperFacebook extends AuthHelper implements TnsOAuth.ITnsAuthH
     };
   }
 
-  public logout(successPage?: string): Promise<void> {
+  public logout(navOptions?: TnsOAuth.INavigationOptions): Promise<void> {
     let cookieDomains = [".facebook.com"]; //need to double check this
-    return this._logout(successPage, cookieDomains);
+    return this._logout(navOptions, cookieDomains);
   }
 }

--- a/auth-helper-google.ts
+++ b/auth-helper-google.ts
@@ -19,8 +19,8 @@ export class AuthHelperGoogle extends AuthHelper implements TnsOAuth.ITnsAuthHel
     };
   }
 
-  public logout(successPage?: string): Promise<void> {
+  public logout(navOptions?: TnsOAuth.INavigationOptions): Promise<void> {
     let cookieDomains = [".google.com"]; //need to double check this
-    return this._logout(successPage, cookieDomains);
+    return this._logout(navOptions, cookieDomains);
   }
 }

--- a/auth-helper-linkedin.ts
+++ b/auth-helper-linkedin.ts
@@ -24,8 +24,8 @@ export class AuthHelperLinkedIn extends AuthHelper implements TnsOAuth.ITnsAuthH
     };
   }
   //Gets cookie domains for logging out
-  public logout(successPage?: string): Promise<void> {
+  public logout(navOptions?: TnsOAuth.INavigationOptions): Promise<void> {
     let cookieDomains = [".linkedin.com"]; 
-    return this._logout(successPage, cookieDomains);
+    return this._logout(navOptions, cookieDomains);
   }
 }

--- a/auth-helper-office365.ts
+++ b/auth-helper-office365.ts
@@ -19,8 +19,8 @@ export class AuthHelperOffice365 extends AuthHelper implements TnsOAuth.ITnsAuth
     };
   }
 
-  public logout(successPage?: string): Promise<void> {
+  public logout(navOptions?: TnsOAuth.INavigationOptions): Promise<void> {
     let cookieDomains = ["login.microsoftonline.com", ".live.com"];
-    return this._logout(successPage, cookieDomains);
+    return this._logout(navOptions, cookieDomains);
   }
 }

--- a/auth-helper-uaa.ts
+++ b/auth-helper-uaa.ts
@@ -27,9 +27,9 @@ export class AuthHelperUaa extends AuthHelper implements TnsOAuth.ITnsAuthHelper
     this._cookieDomains = cookieDomains;
   }
 
-  public logout(successPage?: string): Promise<void> {
+  public logout(navOptions?: TnsOAuth.INavigationOptions): Promise<void> {
     let cookieDomains = this._cookieDomains;
-    return this._logout(successPage, cookieDomains);
+    return this._logout(navOptions, cookieDomains);
   }
 }
 

--- a/auth-helper.ts
+++ b/auth-helper.ts
@@ -11,9 +11,9 @@ export class AuthHelper {
         this.tokenResult = tnsOauth.getTokenFromCache();
     }
 
-    public login(successPage?: string): Promise<string> {
+    public login(navOptions?: TnsOAuth.INavigationOptions): Promise<string> {
         return new Promise((resolve, reject) => {
-            tnsOauth.loginViaAuthorizationCodeFlow(this.credentials, successPage)
+            tnsOauth.loginViaAuthorizationCodeFlow(this.credentials, navOptions)
                 .then((response: TnsOAuth.ITnsOAuthTokenResult) => {
                     this.tokenResult = response;
                     resolve(response.accessToken);
@@ -37,10 +37,10 @@ export class AuthHelper {
         });
     }
 
-    public _logout(successPage?: string, cookieDomains?: string[]): Promise<void> {
+    public _logout(navOptions?: TnsOAuth.INavigationOptions, cookieDomains?: string[]): Promise<void> {
         return new Promise<void>((resolve, reject) => {
             try {
-                tnsOauth.logout(cookieDomains, successPage);
+                tnsOauth.logout(cookieDomains, navOptions);
                 this.tokenResult = null;
                 resolve();
             } catch (er) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,9 @@ export declare function initCustom(options: TnsOAuth.ITnsOAuthOptionsCustom): Pr
 
 export declare function accessToken(): string;
 export declare function login(successPage?: string): Promise<string>;
+export declare function login(navOptions?: TnsOAuth.INavigationOptions): Promise<string>;
 export declare function logout(successPage?: string): Promise<void>;
+export declare function logout(navOptions?: TnsOAuth.INavigationOptions): Promise<void>;
 export declare function accessTokenExpired(): boolean;
 export declare function ensureValidToken(): Promise<string>;
 

--- a/index.ts
+++ b/index.ts
@@ -150,11 +150,23 @@ export function accessToken(): string {
     return instance.tokenResult.accessToken;
 }
 
-export function login(successPage?: string): Promise<string> {
-    return instance.login(successPage);
+export function login(successPage?: string);
+export function login(navOptions?: TnsOAuth.INavigationOptions);
+export function login(navOptions?: TnsOAuth.INavigationOptions | string): Promise<string> {
+    // Don't break legacy api, assign any successPage args to a navOptions obj
+    if (typeof navOptions === "string") {
+        navOptions = { successPage: navOptions };
+    }
+    return instance.login(navOptions);
 }
-export function logout(successPage?: string): Promise<void> {
-    return instance.logout(successPage);
+export function logout(successPage?: string);
+export function logout(navOptions?: TnsOAuth.INavigationOptions);
+export function logout(navOptions?: TnsOAuth.INavigationOptions | string): Promise<void> {
+    // Don't break legacy api, assign any successPage args to a navOptions obj
+    if (typeof navOptions === "string") {
+        navOptions = { successPage: navOptions };
+    }
+    return instance.logout(navOptions);
 }
 export function accessTokenExpired(): boolean {
     return instance.accessTokenExpired();

--- a/tns-oauth-interfaces.d.ts
+++ b/tns-oauth-interfaces.d.ts
@@ -79,4 +79,7 @@ export interface INavigationOptions {
     successPage?: string;
     animated?: boolean;
     transition?: NavigationTransition;
+    actionBarHidden?: boolean;
+    backgroundColor?: string;
+    textColor?: string;
 }

--- a/tns-oauth-interfaces.d.ts
+++ b/tns-oauth-interfaces.d.ts
@@ -1,11 +1,12 @@
+import { NavigationTransition } from "./node_modules/tns-core-modules/ui/frame/frame";
 
 
 
 export interface ITnsAuthHelper {
     credentials: ITnsOAuthCredentials;
     tokenResult: ITnsOAuthTokenResult;
-    login: (successPage?: string) => Promise<string>;
-    logout: (successPage?: string) => Promise<void>;
+    login: (navOptions?: INavigationOptions) => Promise<string>;
+    logout: (navOptions?: INavigationOptions) => Promise<void>;
     refreshToken: () => Promise<string>;
     accessTokenExpired: () => boolean;
     refreshTokenExpired: () => boolean;
@@ -72,4 +73,10 @@ export interface ITnsOAuthOptionsSalesforce extends ITnsOAuthOptions {
 export interface ITnsOAuthOptionsCustom {
     credentials: ITnsOAuthCredentials;
     cookieDomains: Array<string>;
+}
+
+export interface INavigationOptions {
+    successPage?: string;
+    animated?: boolean;
+    transition?: NavigationTransition;
 }

--- a/tns-oauth-page-provider.ts
+++ b/tns-oauth-page-provider.ts
@@ -1,12 +1,13 @@
 /// <reference path="references.d.ts" />
 
-import { Page } from 'ui/page';
+import { Page, Color } from 'ui/page';
 import { GridLayout } from 'ui/layouts/grid-layout';
 import { StackLayout } from 'ui/layouts/stack-layout';
 import { isAndroid } from 'tns-core-modules/platform';
 import { TnsOauthWebView } from './tns-oauth-webview';
 //import { TnsOAuthWebViewDelegateImpl } from './tns-oauth-webview';
 import { TnsOAuthWebViewHelper } from './tns-oauth-webview-helper';
+import { INavigationOptions } from './tns-oauth-interfaces';
 
 
 export class TnsOAuthPageProvider {
@@ -20,7 +21,7 @@ export class TnsOAuthPageProvider {
         this._authUrl = authUrl;
     }
 
-    public loginPageFunc() {
+    public loginPageFunc(options: INavigationOptions) {
         let wv = new TnsOauthWebView(this._cancelEventHandler);
 
         TnsOAuthWebViewHelper.initWithWebViewAndIntercept(wv, this._checkCodeIntercept);
@@ -34,8 +35,19 @@ export class TnsOAuthPageProvider {
         let page = new Page();
         page.content = stack;
 
-        if (isAndroid) {
+        if (options.actionBarHidden !== undefined) {
+            page.actionBarHidden = options.actionBarHidden;
+        } else if (isAndroid) {
             page.actionBarHidden = true;
+        }
+        if (options.backgroundColor) {
+            page.backgroundSpanUnderStatusBar = !!options.backgroundColor;
+            page.backgroundColor = options.backgroundColor;
+            page.actionBar.backgroundColor = options.backgroundColor;
+        }
+
+        if (options.textColor) {
+            page.actionBar.color = new Color(options.textColor);
         }
 
         wv.src = this._authUrl;


### PR DESCRIPTION
Added the ability to style the WebView that is created on login, and to remove or configure the transition animations that occur on login and logout.

The new api is backward compatible as there is still the ability to pass in a `successPage` parameter. The string is picked up and wrapped inside the newly created `INavigationOptions` object.